### PR TITLE
Handle conversation closure and avatars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Development Guidelines
+
+This repo contains a React/Vite frontend. Use the following commands for local development:
+
+```
+npm install        # install dependencies
+npm run dev        # start dev server
+npm run build      # production build
+npm run lint       # check code with ESLint
+```
+
+Always run `npm run lint` before committing changes. Do not commit the `dist` folder or `node_modules`.
+
+The `deploy.sh` script includes credentials for deploying via `rsync`. Keep these secrets private and avoid modifying them in commits.

--- a/src/index.css
+++ b/src/index.css
@@ -1276,6 +1276,18 @@ body {
   /* pointer-events: none; */
 }
 
+.conversation-avatar {
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
 .conversation-card-comment-container {
   position: relative;
   background-color: var(--secondary-color);
@@ -1284,6 +1296,9 @@ body {
   /* border-top-left-radius: 0; */
   max-width: 70%;
   margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .conversation-card-comment-container::after {
@@ -1303,6 +1318,7 @@ body {
   /* border-top-right-radius: 0; */
   margin-right: 0;
   margin-left: auto;
+  flex-direction: row-reverse;
 }
 
 .conversation-card-comment-container.owner::after {

--- a/src/pages/Conversation/Conversation.jsx
+++ b/src/pages/Conversation/Conversation.jsx
@@ -8,6 +8,22 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import DynamicIcon from '../../components/DynamicIcon';
 import { SAMPLE_STATUS } from '../../constants';
 
+const stringToColor = (str) => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const h = hash % 360;
+  return `hsl(${h}, 60%, 50%)`;
+};
+
+const getInitials = (name) => {
+  if (!name) return '';
+  const parts = name.trim().split(' ');
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
 
 
 const Conversation = () => {
@@ -28,8 +44,9 @@ const Conversation = () => {
 
   const checkConversationStatus = () => {
     const timeLine = sample.timeline[0];
-    if (timeLine.status === SAMPLE_STATUS.NEW
-      || timeLine.status === SAMPLE_STATUS.IN_REVIEW
+    if (
+      timeLine.status !== SAMPLE_STATUS.READY &&
+      timeLine.status !== SAMPLE_STATUS.REJECTED
     ) {
       setIsConversationActive(true);
     }
@@ -114,21 +131,26 @@ const Conversation = () => {
             <>
             <div ref={commentsContainerRef} className='comments-container'>
               {
-                conversations.map((conversation) => (
-                  conversation.comment_owner === user.id ? (
-                    <div key={conversation.id} className="conversation-card-comment-container owner">
+                conversations.map((conversation) => {
+                  const isOwner = conversation.comment_owner === user.id;
+                  const name = isOwner ? user.name : conversation.user?.name;
+                  const phone = isOwner ? user.phone : conversation.user?.phone;
+                  const initials = getInitials(name);
+                  const color = stringToColor(phone || '');
+                  return (
+                    <div
+                      key={conversation.id}
+                      className={`conversation-card-comment-container ${isOwner ? 'owner' : ''}`}
+                    >
+                      <div className="conversation-avatar" style={{ backgroundColor: color }}>
+                        {initials}
+                      </div>
                       <div className="conversation-card-comment">
                         {conversation.comment_text}
                       </div>
                     </div>
-                  ) : (
-                    <div key={conversation.id} className="conversation-card-comment-container">
-                      <div className="conversation-card-comment">
-                        {conversation.comment_text}
-                      </div>
-                    </div>
-                  )
-                ))
+                  );
+                })
               }
             </div>
             {


### PR DESCRIPTION
## Summary
- update conversation logic so chat stays open until the sample is marked `ready` or `rejected`
- display sender initials in coloured circle derived from their phone number
- style conversation bubbles for multi-user chat

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68419472199483339ba53bb593d6c571