### PR TITLE
Add sample path to tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Development Guidelines
+
+This repo contains a React/Vite frontend. Use the following commands for local development:
+
+```
+npm install        # install dependencies
+npm run dev        # start dev server
+npm run build      # production build
+npm run lint       # check code with ESLint
+```
+
+Always run `npm run lint` before committing changes. Do not commit the `dist` folder or `node_modules`.
+
+The `deploy.sh` script includes credentials for deploying via `rsync`. Keep these secrets private and avoid modifying them in commits.

--- a/src/index.css
+++ b/src/index.css
@@ -722,6 +722,13 @@ body {
   animation: pulse 1.5s infinite ease-in-out;
 }
 
+.sample-path {
+  font-size: 0.8rem;
+  color: #666;
+  margin: 0;
+  margin-bottom: 4px;
+}
+
 .sample-description {
   display: none;
   font-size: 0.9rem;
@@ -1276,14 +1283,37 @@ body {
   /* pointer-events: none; */
 }
 
+.conversation-avatar {
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.conversation-message {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  margin-bottom: 1.5rem;
+}
+
+.conversation-message.owner {
+  flex-direction: row-reverse;
+}
+
 .conversation-card-comment-container {
   position: relative;
   background-color: var(--secondary-color);
   padding: 14px 20px;
   border-radius: 10px;
-  /* border-top-left-radius: 0; */
   max-width: 70%;
-  margin-bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .conversation-card-comment-container::after {
@@ -1303,12 +1333,25 @@ body {
   /* border-top-right-radius: 0; */
   margin-right: 0;
   margin-left: auto;
+  flex-direction: row-reverse;
 }
 
 .conversation-card-comment-container.owner::after {
   left: auto;
   right: -8px;
   background-color: var(--primary-color);
+}
+
+.conversation-comment-date {
+  font-size: 0.7rem;
+  margin-top: 6px;
+  color: #e0e0e0;
+  align-self: flex-end;
+}
+
+.conversation-message.owner .conversation-comment-date {
+  align-self: flex-start;
+  text-align: right;
 }
 
 /*  END OF CONVERSATION PAGE  */


### PR DESCRIPTION
## Summary
- enhance tasks list to fetch sample info
- display the sample's full path under the ID
- style new `.sample-path` element

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68419472199483339ba53bb593d6c571