### PR TITLE
Show full sample path in tasks

### DIFF
--- a/src/pages/TaskList/TaskList.jsx
+++ b/src/pages/TaskList/TaskList.jsx
@@ -30,7 +30,7 @@ const TaskList = () => {
     const collection = sample.collection?.name || sample.collection_name || '';
     const sub = sample.subcollection?.name || sample.sub_collection?.name || sample.subcollection_name || '';
     const name = sample.name || '';
-    return [collection, sub, name].filter(Boolean).join(' / ');
+    return [collection, sub, name].filter(Boolean).join(' > ');
   };
 
   const getMyTasks = async () => {


### PR DESCRIPTION
## Summary
- display sample path in task list as `Collection > Subcollection > Sample`

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841c16ac13c8333980314ab47c951cb